### PR TITLE
Handle screen rotation, fix existing NPEs

### DIFF
--- a/app/src/main/java/com/frolfr/frolfrclient/activity/courses/CoursesActivity.java
+++ b/app/src/main/java/com/frolfr/frolfrclient/activity/courses/CoursesActivity.java
@@ -45,8 +45,6 @@ public class CoursesActivity extends FrolfrActivity {
                     .add(R.id.main_content, coursesFragment)
                     .commit();
 
-            // The ArrayAdapter will take data from a source and
-            // use it to populate the ListView it's attached to.
             courseListAdapter =
                     new CoursesArrayAdapter(
                             this,
@@ -55,6 +53,14 @@ public class CoursesActivity extends FrolfrActivity {
 
         } else {
             Log.d(getClass().getSimpleName(), "CoursesActivity fragment already created");
+
+            // The ArrayAdapter will take data from a source and
+            // use it to populate the ListView it's attached to.
+            courseListAdapter =
+                    new CoursesArrayAdapter(
+                            this,
+                            R.layout.list_item_course, // The name of the layout ID.
+                            new ArrayList<Course>());
         }
 
     }
@@ -63,6 +69,12 @@ public class CoursesActivity extends FrolfrActivity {
     public void onStart() {
         super.onStart();
         new GetCourseInfoTask().execute();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+//        TODO - save all Course information so we don't have to re-issue web requests
     }
 
 

--- a/app/src/main/java/com/frolfr/frolfrclient/activity/coursescorecards/CourseScorecardsActivity.java
+++ b/app/src/main/java/com/frolfr/frolfrclient/activity/coursescorecards/CourseScorecardsActivity.java
@@ -60,6 +60,14 @@ public class CourseScorecardsActivity extends FrolfrActivity {
 
         } else {
             Log.d(getClass().getSimpleName(), "CourseDetail fragment already created");
+
+            // The ArrayAdapter will take data from a source and
+            // use it to populate the ListView it's attached to.
+            courseScorecardsArrayAdapter =
+                    new CourseScorecardsArrayAdapter(
+                            this,
+                            R.layout.list_item_course_scorecard, // The name of the layout ID.
+                            new ArrayList<Round>());
         }
     }
 

--- a/app/src/main/java/com/frolfr/frolfrclient/activity/newgame/NewGameActivity.java
+++ b/app/src/main/java/com/frolfr/frolfrclient/activity/newgame/NewGameActivity.java
@@ -55,6 +55,11 @@ public class NewGameActivity extends FrolfrActivity {
 
         } else {
             Log.d(getClass().getSimpleName(), "NewGameFragment fragment already created");
+
+            courseAdapter = new CourseSpinnerAdapter(
+                    this,
+                    android.R.layout.simple_list_item_1,
+                    new ArrayList<Course>());
         }
 
     }

--- a/app/src/main/java/com/frolfr/frolfrclient/activity/roundscorecard/HoleDetailAdapter.java
+++ b/app/src/main/java/com/frolfr/frolfrclient/activity/roundscorecard/HoleDetailAdapter.java
@@ -38,24 +38,29 @@ public class HoleDetailAdapter extends ArrayAdapter {
 
         HoleDetail holeDetail = (HoleDetail) getItem(position);
 
-        cv.score.setText(holeDetail.getStrokes() + "");
+        String strokes = holeDetail.getStrokes() == null ? "-" : holeDetail.getStrokes()+"";
+        cv.score.setText(strokes);
         // TODO - ART
-        switch (holeDetail.getScoreType()) {
-            case DOUBLE_BOGIE:
-                cv.score.setBackgroundColor(Color.RED);
-                break;
-            case BOGIE:
-                cv.score.setBackgroundColor(Color.MAGENTA);
-                break;
-            case PAR:
-                cv.score.setBackgroundColor(Color.WHITE);
-                break;
-            case BIRDIE:
-                cv.score.setBackgroundColor(Color.GREEN);
-                break;
-            case EAGLE:
-                cv.score.setBackgroundColor(Color.BLUE);
-                break;
+        if (holeDetail.getScoreType() != null) {
+            switch (holeDetail.getScoreType()) {
+                case DOUBLE_BOGIE:
+                    cv.score.setBackgroundColor(Color.RED);
+                    break;
+                case BOGIE:
+                    cv.score.setBackgroundColor(Color.MAGENTA);
+                    break;
+                case PAR:
+                    cv.score.setBackgroundColor(Color.WHITE);
+                    break;
+                case BIRDIE:
+                    cv.score.setBackgroundColor(Color.GREEN);
+                    break;
+                case EAGLE:
+                    cv.score.setBackgroundColor(Color.BLUE);
+                    break;
+            }
+        } else {
+            cv.score.setBackgroundColor(Color.GRAY);
         }
 
         return convertView;

--- a/app/src/main/java/com/frolfr/frolfrclient/activity/roundscorecard/RoundScorecardActivity.java
+++ b/app/src/main/java/com/frolfr/frolfrclient/activity/roundscorecard/RoundScorecardActivity.java
@@ -55,6 +55,10 @@ public class RoundScorecardActivity extends FrolfrActivity {
 
         } else {
             // Fragment already created
+
+            scorecards = new ArrayList<>();
+            scorecardAdapter = new PlayerScorecardAdapter(this, 0, scorecards);
+            scorecardDetailFragment = (RoundScorecardFragment) getSupportFragmentManager().findFragmentById(R.id.main_content);
         }
     }
 
@@ -150,7 +154,11 @@ public class RoundScorecardActivity extends FrolfrActivity {
                         JSONObject turn = turns.getJSONObject(i);
                         int turnId = turn.getInt("id");
                         int hole = turn.getInt("hole_number");
-                        int strokes = turn.getInt("strokes");           // TODO strokes can be null on incomplete scorecards
+                        Integer strokes = null;
+                        // TODO - why is this JSON lib interpreting null as a String? JSON 1 vs JSON 2?
+                        if (turn.get("strokes") != null && turn.get("strokes") instanceof Integer) {
+                            strokes = turn.getInt("strokes");
+                        }
                         int par = turn.getInt("par");
                         HoleDetail holeDetail = new HoleDetail(hole, strokes, par);
                         turnMap.put(turnId, holeDetail);
@@ -174,6 +182,7 @@ public class RoundScorecardActivity extends FrolfrActivity {
 
                 } catch (JSONException e) {
                     Log.e(getClass().getSimpleName(), "Malformed JSON response:\n" + jsonResponse, e);
+                    e.printStackTrace();
                 }
 
             }

--- a/app/src/main/java/com/frolfr/frolfrclient/entity/HoleDetail.java
+++ b/app/src/main/java/com/frolfr/frolfrclient/entity/HoleDetail.java
@@ -10,10 +10,12 @@ public class HoleDetail {
     Integer scoreDiff;
     SCORE_TYPE scoreType;
 
-    public HoleDetail(int hole, int strokes, int par) {
+    public HoleDetail(int hole, Integer strokes, int par) {
         this.hole = hole;
         this.strokes = strokes;
-        this.scoreDiff = par - strokes;
+        if (strokes != null) {
+            this.scoreDiff = par - strokes;
+        }
         this.scoreType = SCORE_TYPE.byScoreDiff(scoreDiff);
     }
 

--- a/app/src/main/java/com/frolfr/frolfrclient/entity/Scorecard.java
+++ b/app/src/main/java/com/frolfr/frolfrclient/entity/Scorecard.java
@@ -22,7 +22,7 @@ public class Scorecard {
         while (holeIter.hasNext()) {
             HoleDetail detail = holeIter.next();
             if (detail.getScoreDiff() != null)
-                this.totalScore += holeIter.next().getScoreDiff();
+                this.totalScore += detail.getScoreDiff();
         }
     }
 


### PR DESCRIPTION
Crudely handled screen rotation for now by reinstantiating all member variables from scratch. Need to store some instance state to not reissue web requests. Handled NPEs in round scorecard json responses (strokes can be null for skipped holes)